### PR TITLE
Add sunrise sunset

### DIFF
--- a/window.go
+++ b/window.go
@@ -5,99 +5,229 @@
 package window
 
 import (
+	"fmt"
 	"time"
+
+	sunrise "github.com/nathan-osman/go-sunrise"
+)
+
+const (
+	hourMinuteFormat = "15:04"
 )
 
 // New creates a Window instance which represents a recurring window
 // between two times of day. If `start` is after `end` then the time
 // window is assumed to cross over midnight. If `start` and `end` are
 // the same then the window is always active.
-func New(start, end time.Time) *Window {
-	start = normaliseTime(start)
-	end = normaliseTime(end)
+func New(start, end string, lat, long float64) (*Window, error) {
+	startTime, err := parseAbsOrRelField(start)
+	if err != nil {
+		return nil, err
+	}
+	endTime, err := parseAbsOrRelField(end)
+	if err != nil {
+		return nil, err
+	}
 
-	xMidnight := false
-	if end.Before(start) {
-		end = addDay(end)
-		xMidnight = true
+	if !startTime.Relative && start == end {
+		return &Window{NoWindow: true}, nil
 	}
 
 	return &Window{
-		Start:     start,
-		End:       end,
+		start:     startTime,
+		end:       endTime,
+		Latitude:  lat,
+		Longitude: long,
 		Now:       time.Now,
-		xMidnight: xMidnight,
-	}
+	}, nil
 }
 
 // Window represents a recurring window between two times of day.
 // The Now field can be use to override the time source (for testing).
 type Window struct {
-	Start     time.Time
-	End       time.Time
-	Now       func() time.Time
-	xMidnight bool
+	start *absOrRelTime
+	end   *absOrRelTime
+
+	Latitude  float64
+	Longitude float64
+
+	Now func() time.Time
+
+	NoWindow bool
+}
+
+func parseAbsOrRelField(timeStr string) (*absOrRelTime, error) {
+	t := &absOrRelTime{}
+
+	absTime, err := time.Parse("15:04", timeStr)
+	if err == nil {
+		t.Time = absTime
+		t.Relative = false
+		return t, nil
+	}
+
+	duration, err := time.ParseDuration(timeStr)
+	if err == nil {
+		t.RelativeDuration = duration
+		t.Relative = true
+		return t, nil
+	}
+
+	return nil, fmt.Errorf("could not parse '%s' as a time or duration", timeStr)
+}
+
+type absOrRelTime struct {
+	Time             time.Time
+	Relative         bool
+	RelativeDuration time.Duration
+}
+
+// NextEnd will give the next time the window will end.
+func (w *Window) NextEnd() time.Time {
+	if w.end.Relative {
+		return w.nextRelativeEnd()
+	}
+	return nextAbsTime(w.Now(), w.end.Time)
+}
+
+// NextStart will give the next time the windiw will start.
+func (w *Window) NextStart() time.Time {
+	if w.start.Relative {
+		return w.nextRelativeStart()
+	}
+	return nextAbsTime(w.Now(), w.start.Time)
+}
+
+// PreviousStart will give the time the window last started.
+func (w *Window) PreviousStart() time.Time {
+	if w.start.Relative {
+		return w.previousRelativeStart()
+	}
+	return nextAbsTime(w.Now().Add(-24*time.Hour), w.start.Time)
+}
+
+func (w *Window) relativeSunriseOn(year int, month time.Month, day int) time.Time {
+	if !w.start.Relative {
+		return time.Time{}
+	}
+	sr, _ := sunrise.SunriseSunset(w.Latitude, w.Longitude, year, month, day)
+	return sr.Add(w.end.RelativeDuration)
+}
+
+func (w *Window) relativeSunsetOn(year int, month time.Month, day int) time.Time {
+	if !w.end.Relative {
+		return time.Time{}
+	}
+	_, ss := sunrise.SunriseSunset(w.Latitude, w.Longitude, year, month, day)
+	return ss.Add(w.start.RelativeDuration)
+}
+
+func (w *Window) nextRelativeEnd() time.Time {
+	now := w.Now()
+	t := w.relativeSunriseOn(now.Year(), now.Month(), now.Day())
+	if t.After(now) {
+		return t
+	}
+	return w.relativeSunriseOn(now.Year(), now.Month(), now.Day()+1)
+}
+
+func (w *Window) nextRelativeStart() time.Time {
+	now := w.Now()
+	t := w.relativeSunsetOn(now.Year(), now.Month(), now.Day())
+	if t.After(now) {
+		return t
+	}
+	return w.relativeSunsetOn(now.Year(), now.Month(), now.Day()+1)
+}
+
+func (w *Window) previousRelativeStart() time.Time {
+	now := w.Now()
+	t := w.relativeSunsetOn(now.Year(), now.Month(), now.Day())
+	if t.Before(now) {
+		return t
+	}
+	return w.relativeSunsetOn(now.Year(), now.Month(), now.Day()-1)
+}
+
+func nextAbsTime(now, absTime time.Time) time.Time {
+	absTime = setTimeHourAndMinute(now, absTime.Hour(), absTime.Minute())
+	if absTime.After(now) {
+		return absTime
+	}
+	now = addDay(now)
+	return setTimeHourAndMinute(now, absTime.Hour(), absTime.Minute())
+}
+
+func setTimeHourAndMinute(t time.Time, hour, minute int) time.Time {
+	return time.Date(t.Year(), t.Month(), t.Day(), hour, minute, 0, 0, t.Location())
 }
 
 // Active returns true if the time window is currently active.
 func (w *Window) Active() bool {
-	return w.Until() == time.Duration(0)
+	if w.NoWindow {
+		return true
+	}
+	return w.NextEnd().Before(w.NextStart())
 }
 
 // Until returns the duration until the next time window starts.
 func (w *Window) Until() time.Duration {
-	if w.Start == w.End {
+	if w.NoWindow || w.Active() {
 		return time.Duration(0)
 	}
-
-	now := w.nowTimeAfterStart()
-
-	if w.End.After(now) {
-		// During window.
-		return time.Duration(0)
-	}
-	// After window.
-	return addDay(w.Start).Sub(now)
+	return w.NextStart().Sub(w.Now())
 }
 
 func addDay(t time.Time) time.Time {
 	return t.Add(24 * time.Hour)
 }
 
-// nowTimeAfterStart to make time calculations easier we choose a date time to represent now
-// that is on or the next one after the start time
-func (w *Window) nowTimeAfterStart() time.Time {
-	now := normaliseTime(w.Now())
-	if now.Before(w.Start) {
-		now = addDay(now)
-	}
-	return now
-}
-
-func normaliseTime(t time.Time) time.Time {
-	return time.Date(1, 1, 1, t.Hour(), t.Minute(), t.Second(), 0, time.UTC)
-}
-
 // UntilEnd returns the duration until the end of the time window.
 func (w *Window) UntilEnd() time.Duration {
-	if (w.Active()) {
-		return w.End.Sub(w.nowTimeAfterStart())
+	if w.NoWindow || !w.Active() {
+		return time.Duration(0)
 	}
-	return time.Duration(0)
+	return w.NextEnd().Sub(w.Now())
 }
 
 // UntilNextInterval gets when the next interval starts.
 // Only works when window is currently active.
 func (w *Window) UntilNextInterval(interval time.Duration) time.Duration {
-	if (w.Active()) {
-		now := w.nowTimeAfterStart()
-		elapsedTime := now.Sub(w.Start)
-		nextInterval := w.Start.Add(elapsedTime.Truncate(interval) + interval)
+	if w.NoWindow || !w.Active() {
+		return time.Duration(-1)
+	}
 
-		if (w.End.After(nextInterval)) {
-			return nextInterval.Sub(now)
-		}
+	start := w.PreviousStart()
+	end := w.NextEnd()
+	elapsedTime := w.Now().Sub(start)
+	nextInterval := start.Add(elapsedTime.Truncate(interval) + interval)
+
+	if end.After(nextInterval) {
+		return nextInterval.Sub(w.Now())
 	}
 
 	return time.Duration(-1)
+}
+
+func (w Window) String() string {
+	s := fmt.Sprint("window starts at ")
+	s = s + " and ends at "
+
+	return fmt.Sprintf("window starts at %s and ends at %s", w.start.string("sunset"), w.end.string("sunrise"))
+}
+
+func (t absOrRelTime) string(relativeTo string) string {
+	var s string
+	if t.Relative {
+		if t.RelativeDuration < 0 {
+			s = s + fmt.Sprintf("%v before %s", -1*t.RelativeDuration, relativeTo)
+		} else if t.RelativeDuration > 0 {
+			s = s + fmt.Sprintf("%v after %s", t.RelativeDuration, relativeTo)
+		} else {
+			s = s + fmt.Sprintf("at %s", relativeTo)
+		}
+	} else {
+		s = s + fmt.Sprintf("%v ", t.Time.Format(hourMinuteFormat))
+	}
+	return s
 }

--- a/window.go
+++ b/window.go
@@ -11,9 +11,7 @@ import (
 	sunrise "github.com/nathan-osman/go-sunrise"
 )
 
-const (
-	hourMinuteFormat = "15:04"
-)
+const hourMinuteFormat = "15:04"
 
 // New creates a Window instance which represents a recurring window
 // between two times of day. If `start` is after `end` then the time
@@ -45,21 +43,18 @@ func New(start, end string, lat, long float64) (*Window, error) {
 // Window represents a recurring window between two times of day.
 // The Now field can be use to override the time source (for testing).
 type Window struct {
-	start *absOrRelTime
-	end   *absOrRelTime
-
+	start     *absOrRelTime
+	end       *absOrRelTime
 	Latitude  float64
 	Longitude float64
-
-	Now func() time.Time
-
-	NoWindow bool
+	Now       func() time.Time
+	NoWindow  bool
 }
 
 func parseAbsOrRelField(timeStr string) (*absOrRelTime, error) {
 	t := &absOrRelTime{}
 
-	absTime, err := time.Parse("15:04", timeStr)
+	absTime, err := time.Parse(hourMinuteFormat, timeStr)
 	if err == nil {
 		t.Time = absTime
 		t.Relative = false
@@ -90,7 +85,7 @@ func (w *Window) NextEnd() time.Time {
 	return nextAbsTime(w.Now(), w.end.Time)
 }
 
-// NextStart will give the next time the windiw will start.
+// NextStart will give the next time the window will start.
 func (w *Window) NextStart() time.Time {
 	if w.start.Relative {
 		return w.nextRelativeStart()
@@ -210,9 +205,6 @@ func (w *Window) UntilNextInterval(interval time.Duration) time.Duration {
 }
 
 func (w Window) String() string {
-	s := fmt.Sprint("window starts at ")
-	s = s + " and ends at "
-
 	return fmt.Sprintf("window starts at %s and ends at %s", w.start.string("sunset"), w.end.string("sunrise"))
 }
 

--- a/window.go
+++ b/window.go
@@ -34,8 +34,8 @@ func New(start, end string, lat, long float64) (*Window, error) {
 	return &Window{
 		start:     startTime,
 		end:       endTime,
-		Latitude:  lat,
-		Longitude: long,
+		latitude:  lat,
+		longitude: long,
 		Now:       time.Now,
 	}, nil
 }
@@ -45,8 +45,8 @@ func New(start, end string, lat, long float64) (*Window, error) {
 type Window struct {
 	start     *absOrRelTime
 	end       *absOrRelTime
-	Latitude  float64
-	Longitude float64
+	latitude  float64
+	longitude float64
 	Now       func() time.Time
 	NoWindow  bool
 }
@@ -105,7 +105,7 @@ func (w *Window) relativeSunriseOn(year int, month time.Month, day int) time.Tim
 	if !w.start.Relative {
 		return time.Time{}
 	}
-	sr, _ := sunrise.SunriseSunset(w.Latitude, w.Longitude, year, month, day)
+	sr, _ := sunrise.SunriseSunset(w.latitude, w.longitude, year, month, day)
 	return sr.Add(w.end.RelativeDuration)
 }
 
@@ -113,7 +113,7 @@ func (w *Window) relativeSunsetOn(year int, month time.Month, day int) time.Time
 	if !w.end.Relative {
 		return time.Time{}
 	}
-	_, ss := sunrise.SunriseSunset(w.Latitude, w.Longitude, year, month, day)
+	_, ss := sunrise.SunriseSunset(w.latitude, w.longitude, year, month, day)
 	return ss.Add(w.start.RelativeDuration)
 }
 

--- a/window_test.go
+++ b/window_test.go
@@ -8,31 +8,40 @@ import (
 	"testing"
 	"time"
 
+	sunrise "github.com/nathan-osman/go-sunrise"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testLatitude  = -41
+	testLongitude = 175
 )
 
 func TestNoWindow(t *testing.T) {
-	zero := time.Time{}
-	w := New(zero, zero)
+	zero := time.Time{}.Format(hourMinuteFormat)
+	w, err := New(zero, zero, 0, 0)
+	assert.NoError(t, err)
 	assert.True(t, w.Active())
 }
 
 func TestSameStartEnd(t *testing.T) {
 	// Treat this as "no window"
-	now := time.Now()
-	w := New(now, now)
+	now := time.Now().Format(hourMinuteFormat)
+	w, _ := New(now, now, 0, 0)
 
 	assert.True(t, w.Active())
 	assert.Equal(t, time.Duration(0), w.Until())
 }
 
 func TestStartLessThanEnd(t *testing.T) {
-	w := New(mkTime(9, 10), mkTime(17, 30))
+	w, err := New(mkTime(9, 10), mkTime(17, 30), 0, 0)
+	assert.NoError(t, err)
 	interval := time.Duration(30 * time.Minute)
-
 	w.Now = mkNow(9, 9)
-	assert.False(t, w.Active())
+	//assert.False(t, w.Active())
 	assert.Equal(t, time.Minute, w.Until())
+
 	assert.Equal(t, time.Duration(-1), w.UntilNextInterval(interval))
 	assert.Equal(t, time.Duration(0), w.UntilEnd())
 
@@ -62,7 +71,8 @@ func TestStartLessThanEnd(t *testing.T) {
 
 func TestStartGreaterThanEnd(t *testing.T) {
 	// Window goes over midnight
-	w := New(mkTime(22, 10), mkTime(9, 50))
+	w, err := New(mkTime(22, 10), mkTime(9, 50), 0, 0)
+	assert.NoError(t, err)
 	interval := time.Duration(30 * time.Minute)
 
 	w.Now = mkNow(22, 9)
@@ -112,7 +122,8 @@ func TestStartGreaterThanEnd(t *testing.T) {
 
 func TestMorningToMorning(t *testing.T) {
 	// Window not active just between 10am and 11am each day.
-	w := New(mkTime(11, 0), mkTime(10, 0))
+	w, err := New(mkTime(11, 0), mkTime(10, 0), 0, 0)
+	assert.NoError(t, err)
 
 	w.Now = mkNow(9, 59)
 	assert.True(t, w.Active())
@@ -138,12 +149,101 @@ func TestMorningToMorning(t *testing.T) {
 	assert.Equal(t, 16*time.Hour, w.UntilEnd())
 }
 
-func mkTime(hour, minute int) time.Time {
-	return time.Date(1, 1, 1, hour, minute, 0, 0, time.UTC)
+func TestSettingLatLong(t *testing.T) {
+	lat := 123.0
+	long := 80.0
+	w, err := New("1h", "1h", lat, long)
+	require.NoError(t, err)
+	assert.Equal(t, lat, w.Latitude)
+	assert.Equal(t, long, w.Longitude)
+}
+
+func TestParsingOfWindow(t *testing.T) {
+	w, err := New("20:10", "08:00", 0, 0)
+	require.NoError(t, err)
+	require.False(t, w.start.Relative)
+	assert.Equal(t, w.start.Time.Hour(), 20)
+	assert.Equal(t, w.start.Time.Minute(), 10)
+	require.False(t, w.end.Relative)
+	assert.Equal(t, w.end.Time.Hour(), 8)
+	assert.Equal(t, w.end.Time.Minute(), 0)
+
+	w, err = New("-1h20m", "10:31", 0, 0)
+	require.NoError(t, err)
+	require.True(t, w.start.Relative)
+	assert.Equal(t, w.start.RelativeDuration, -1*(time.Hour+time.Minute*20))
+	require.False(t, w.end.Relative)
+	assert.Equal(t, w.end.Time.Hour(), 10)
+	assert.Equal(t, w.end.Time.Minute(), 31)
+
+	w, err = New("21:59", "3h", 0, 0)
+	require.NoError(t, err)
+	require.False(t, w.start.Relative)
+	assert.Equal(t, w.start.Time.Hour(), 21)
+	assert.Equal(t, w.start.Time.Minute(), 59)
+	require.True(t, w.end.Relative)
+	assert.Equal(t, w.end.RelativeDuration, 3*time.Hour)
+
+	w, err = New("30m", "-1h45m", 0, 0)
+	require.NoError(t, err)
+	require.True(t, w.start.Relative)
+	assert.Equal(t, w.start.RelativeDuration, 30*time.Minute)
+	require.True(t, w.end.Relative)
+	assert.Equal(t, w.end.RelativeDuration, -1*(time.Hour+45*time.Minute))
+
+	_, err = New("abc", "1:30", 0, 0)
+	assert.Error(t, err)
+	_, err = New("1:30", "abc", 0, 0)
+	assert.Error(t, err)
+	_, err = New("-1a", "1:30", 0, 0)
+	assert.Error(t, err)
+}
+
+func TestSunriseSunset(t *testing.T) {
+	nzTimeLoc, err := time.LoadLocation("NZ")
+	require.NoError(t, err)
+	notActiveNowDate := mkNowDate(2000, 1, 2, 12, 0, nzTimeLoc)
+	w, err := New("-1h", "2h", testLatitude, testLongitude) // Window one hour before sunrise to two hours after sunset
+	require.NoError(t, err)
+	w.Now = notActiveNowDate
+	require.Equal(t, time.Duration(-1*time.Hour), w.start.RelativeDuration)
+	require.Equal(t, time.Duration(2*time.Hour), w.end.RelativeDuration)
+	_, todaySunset := sunrise.SunriseSunset(testLatitude, testLongitude, 2000, 1, 2)
+	tomorrowSunrise, tomorrowSunset := sunrise.SunriseSunset(testLatitude, testLongitude, 2000, 1, 3)
+	_, yesterdaySunset := sunrise.SunriseSunset(testLatitude, testLongitude, 2000, 1, 1)
+
+	assert.Equal(t, yesterdaySunset.Add(-1*time.Hour), w.PreviousStart())
+	assert.Equal(t, todaySunset.Add(-1*time.Hour), w.NextStart())
+	assert.Equal(t, tomorrowSunrise.Add(2*time.Hour), w.NextEnd())
+	assert.False(t, w.Active())
+	assert.Equal(t, w.NextStart().Sub(notActiveNowDate()), w.Until())
+	assert.Equal(t, time.Duration(0), w.UntilEnd())
+	assert.Equal(t, time.Duration(-1), w.UntilNextInterval(5*time.Minute))
+
+	activeNowDate := mkNowDate(2000, 1, 2, 21, 1, nzTimeLoc)
+	w.Now = activeNowDate
+	assert.Equal(t, todaySunset.Add(-1*time.Hour), w.PreviousStart())
+	assert.Equal(t, tomorrowSunset.Add(-1*time.Hour), w.NextStart())
+	assert.Equal(t, tomorrowSunrise.Add(2*time.Hour), w.NextEnd())
+	assert.True(t, w.Active())
+	assert.Equal(t, time.Duration(0), w.Until())
+	assert.Equal(t, w.NextEnd().Sub(activeNowDate()), w.UntilEnd())
+	timeUntil14thInterval := w.PreviousStart().Add(time.Duration(14 * 5 * time.Minute)).Sub(activeNowDate())
+	assert.Equal(t, timeUntil14thInterval, w.UntilNextInterval(5*time.Minute))
+}
+
+func mkTime(hour, minute int) string {
+	return time.Date(1, 1, 1, hour, minute, 0, 0, time.UTC).Format(hourMinuteFormat)
 }
 
 func mkNow(hour, minute int) func() time.Time {
 	return func() time.Time {
 		return time.Date(2017, 1, 2, hour, minute, 0, 0, time.UTC)
+	}
+}
+
+func mkNowDate(year int, month time.Month, day, hour, minute int, loc *time.Location) func() time.Time {
+	return func() time.Time {
+		return time.Date(year, month, day, hour, minute, 0, 0, loc)
 	}
 }

--- a/window_test.go
+++ b/window_test.go
@@ -28,8 +28,8 @@ func TestNoWindow(t *testing.T) {
 func TestSameStartEnd(t *testing.T) {
 	// Treat this as "no window"
 	now := time.Now().Format(hourMinuteFormat)
-	w, _ := New(now, now, 0, 0)
-
+	w, err := New(now, now, 0, 0)
+	require.NoError(t, err)
 	assert.True(t, w.Active())
 	assert.Equal(t, time.Duration(0), w.Until())
 }
@@ -39,7 +39,7 @@ func TestStartLessThanEnd(t *testing.T) {
 	assert.NoError(t, err)
 	interval := time.Duration(30 * time.Minute)
 	w.Now = mkNow(9, 9)
-	//assert.False(t, w.Active())
+	assert.False(t, w.Active())
 	assert.Equal(t, time.Minute, w.Until())
 
 	assert.Equal(t, time.Duration(-1), w.UntilNextInterval(interval))
@@ -203,7 +203,7 @@ func TestSunriseSunset(t *testing.T) {
 	nzTimeLoc, err := time.LoadLocation("NZ")
 	require.NoError(t, err)
 	notActiveNowDate := mkNowDate(2000, 1, 2, 12, 0, nzTimeLoc)
-	w, err := New("-1h", "2h", testLatitude, testLongitude) // Window one hour before sunrise to two hours after sunset
+	w, err := New("-1h", "2h", testLatitude, testLongitude) // Window one hour before sunset to two hours after sunrise
 	require.NoError(t, err)
 	w.Now = notActiveNowDate
 	require.Equal(t, time.Duration(-1*time.Hour), w.start.RelativeDuration)

--- a/window_test.go
+++ b/window_test.go
@@ -154,8 +154,8 @@ func TestSettingLatLong(t *testing.T) {
 	long := 80.0
 	w, err := New("1h", "1h", lat, long)
 	require.NoError(t, err)
-	assert.Equal(t, lat, w.Latitude)
-	assert.Equal(t, long, w.Longitude)
+	assert.Equal(t, lat, w.latitude)
+	assert.Equal(t, long, w.longitude)
 }
 
 func TestParsingOfWindow(t *testing.T) {

--- a/window_test.go
+++ b/window_test.go
@@ -2,34 +2,32 @@
 // Use of this source code is governed by the Apache License Version 2.0;
 // see the LICENSE file for further details.
 
-package window_test
+package window
 
 import (
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
-
-	"github.com/TheCacophonyProject/window"
 )
 
 func TestNoWindow(t *testing.T) {
 	zero := time.Time{}
-	w := window.New(zero, zero)
+	w := New(zero, zero)
 	assert.True(t, w.Active())
 }
 
 func TestSameStartEnd(t *testing.T) {
 	// Treat this as "no window"
 	now := time.Now()
-	w := window.New(now, now)
+	w := New(now, now)
 
 	assert.True(t, w.Active())
 	assert.Equal(t, time.Duration(0), w.Until())
 }
 
 func TestStartLessThanEnd(t *testing.T) {
-	w := window.New(mkTime(9, 10), mkTime(17, 30))
+	w := New(mkTime(9, 10), mkTime(17, 30))
 	interval := time.Duration(30 * time.Minute)
 
 	w.Now = mkNow(9, 9)
@@ -64,7 +62,7 @@ func TestStartLessThanEnd(t *testing.T) {
 
 func TestStartGreaterThanEnd(t *testing.T) {
 	// Window goes over midnight
-	w := window.New(mkTime(22, 10), mkTime(9, 50))
+	w := New(mkTime(22, 10), mkTime(9, 50))
 	interval := time.Duration(30 * time.Minute)
 
 	w.Now = mkNow(22, 9)
@@ -114,7 +112,7 @@ func TestStartGreaterThanEnd(t *testing.T) {
 
 func TestMorningToMorning(t *testing.T) {
 	// Window not active just between 10am and 11am each day.
-	w := window.New(mkTime(11, 0), mkTime(10, 0))
+	w := New(mkTime(11, 0), mkTime(10, 0))
 
 	w.Now = mkNow(9, 59)
 	assert.True(t, w.Active())


### PR DESCRIPTION
Window can now bet set to be relative to sunset and sunrise.
If the input time is of the form `hh:mm` the window will start/end at that time.
If the input is of the form `1h20m` or `-2h20m` (https://godoc.org/time#ParseDuration) it will start/end relative to the sunset/sunrise of that day.
Latitude and Longitude is also needed now to get the sunset/sunrise times.